### PR TITLE
Upgrade rspec version to 3.3. Remove all rspec deprecation warnings.

### DIFF
--- a/excel_templating.gemspec
+++ b/excel_templating.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = "A library which allows you to slam data into excel files using mustaching."
   gem.description   = "."
   gem.license       = "MIT"
-  gem.authors       = ["bramski"]
+  gem.authors       = ["bramski", "Mykola Kyryk"]
   gem.email         = "bramski@gmail.com"
   gem.homepage      = "https://github.com/payrollhero/excel_templating"
 
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'bundler', '~> 1.0'
   gem.add_development_dependency 'rake', '~> 0.8'
-  gem.add_development_dependency 'rspec', '~> 2.4'
+  gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
   gem.add_development_dependency 'yard', '~> 0.8'
   gem.add_development_dependency 'rspec-its'

--- a/lib/excel_templating/rspec_excel_matcher.rb
+++ b/lib/excel_templating/rspec_excel_matcher.rb
@@ -9,7 +9,6 @@ require "roo-xls"
 #     end
 #   end
 RSpec::Matchers.define :match_excel_content do |expected_excel_path|
-
   match do |excel_path|
     @excel_matcher = RSpec::Matchers::ExcelMatcher.new
     @excel_matcher.expected_roo = Roo::Spreadsheet.open(expected_excel_path)
@@ -17,15 +16,14 @@ RSpec::Matchers.define :match_excel_content do |expected_excel_path|
     @excel_matcher.match?
   end
 
-  failure_message_for_should do |excel_path|
+  failure_message do |excel_path|
     "expected excel:#{expected_excel_path} to exactly match the content of #{excel_path} but did not.\n" +
       @excel_matcher.errors.join("\n") + "\n"
   end
 
-  failure_message_for_should_not do |excel_path|
+  failure_message_when_negated do |excel_path|
     "expected excel:#{expected_excel_path} to not exactly match the content of #{excel_path} but it did."
   end
-
 end
 
 # Specific Matcher class helper for comparing two excel documents.

--- a/lib/excel_templating/version.rb
+++ b/lib/excel_templating/version.rb
@@ -1,4 +1,4 @@
 module ExcelTemplating
   # excel_templating version
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/excel_abstraction/active_cell_reference_spec.rb
+++ b/spec/excel_abstraction/active_cell_reference_spec.rb
@@ -5,32 +5,32 @@ describe ExcelAbstraction::ActiveCellReference do
 
   describe "#up" do
     it "moves to the cell above" do
-      subject.up.should eq(ExcelAbstraction::CellReference.new(row: 1, col: 3))
+      expect(subject.up).to eq(ExcelAbstraction::CellReference.new(row: 1, col: 3))
     end
   end
 
   describe "#down" do
     it "moves to the cell above" do
-      subject.down.should eq(ExcelAbstraction::CellReference.new(row: 3, col: 3))
+      expect(subject.down).to eq(ExcelAbstraction::CellReference.new(row: 3, col: 3))
     end
   end
 
   describe "#left" do
     it "moves to the cell above" do
-      subject.left.should eq(ExcelAbstraction::CellReference.new(row: 2, col: 2))
+      expect(subject.left).to eq(ExcelAbstraction::CellReference.new(row: 2, col: 2))
     end
   end
 
   describe "#right" do
     it "moves to the cell above" do
-      subject.right.should eq(ExcelAbstraction::CellReference.new(row: 2, col: 4))
+      expect(subject.right).to eq(ExcelAbstraction::CellReference.new(row: 2, col: 4))
     end
   end
 
   describe "#move" do
     context "when the movement commands are supported" do
       it "moves to the cell position specified" do
-        subject.move(right: 2).should eq(ExcelAbstraction::CellReference.new(row: 2, col: 5))
+        expect(subject.move(right: 2)).to eq(ExcelAbstraction::CellReference.new(row: 2, col: 5))
       end
     end
 
@@ -43,31 +43,31 @@ describe ExcelAbstraction::ActiveCellReference do
 
   describe "#carriage_return" do
     it "moves to the cell at the beginning of the row" do
-      subject.carriage_return.should eq(ExcelAbstraction::CellReference.new(row: 2, col: 0))
+      expect(subject.carriage_return).to eq(ExcelAbstraction::CellReference.new(row: 2, col: 0))
     end
   end
 
   describe "#linefeed" do
     it "moves to the cell in the next row" do
-      subject.linefeed.should eq(ExcelAbstraction::CellReference.new(row: 3, col: 3))
+      expect(subject.linefeed).to eq(ExcelAbstraction::CellReference.new(row: 3, col: 3))
     end
   end
 
   describe "#newline" do
     it "moves to the cell above" do
-      subject.newline.should eq(ExcelAbstraction::CellReference.new(row: 3, col: 0))
+      expect(subject.newline).to eq(ExcelAbstraction::CellReference.new(row: 3, col: 0))
     end
   end
 
   describe "#goto" do
     it "moves to the cell above" do
-      subject.goto(5, 5).should eq(ExcelAbstraction::CellReference.new(row: 5, col: 5))
+      expect(subject.goto(5, 5)).to eq(ExcelAbstraction::CellReference.new(row: 5, col: 5))
     end
   end
 
   describe "#reset" do
     it "moves to the cell above" do
-      subject.reset.should eq(ExcelAbstraction::CellReference.new(row: 0, col: 0))
+      expect(subject.reset).to eq(ExcelAbstraction::CellReference.new(row: 0, col: 0))
     end
   end
 end

--- a/spec/excel_abstraction/cell_range_spec.rb
+++ b/spec/excel_abstraction/cell_range_spec.rb
@@ -11,7 +11,7 @@ describe ExcelAbstraction::CellRange do
     end
 
     it "enumerates over the cell references in the range" do
-      subject.inject(0) { |sum, cell| sum + (cell.row * cell.col) }.should == 3
+      expect(subject.inject(0) { |sum, cell| sum + (cell.row * cell.col) }).to eq 3
     end
   end
 
@@ -29,7 +29,7 @@ describe ExcelAbstraction::CellRange do
     context "when the cell to be inserted is in the same row" do
       it "inserts the cell" do
         subject << {row: 1, col: 1}
-        subject.last.should eq(ExcelAbstraction::CellReference.new(row: 1, col: 1))
+        expect(subject.last).to eq(ExcelAbstraction::CellReference.new(row: 1, col: 1))
       end
     end
   end

--- a/spec/excel_abstraction/cell_reference_spec.rb
+++ b/spec/excel_abstraction/cell_reference_spec.rb
@@ -9,7 +9,7 @@ describe ExcelAbstraction::CellReference do
         let(:other){ described_class.new(row: 1, col: 0) }
 
         it "returns 1" do
-          (subject <=> other).should == 1
+          expect(subject <=> other).to eq 1
         end
       end
 
@@ -17,7 +17,7 @@ describe ExcelAbstraction::CellReference do
         let(:other){ described_class.new(row: 1, col: 1) }
 
         it "returns 0" do
-          (subject <=> other).should == 0
+          expect(subject <=> other).to eq 0
         end
       end
 
@@ -25,7 +25,7 @@ describe ExcelAbstraction::CellReference do
         let(:other){ described_class.new(row: 1, col: 2) }
 
         it "returns -1" do
-          (subject <=> other).should == -1
+          expect(subject <=> other).to eq -1
         end
       end
     end
@@ -34,7 +34,7 @@ describe ExcelAbstraction::CellReference do
       let(:other){ described_class.new(row: 0, col: 0) }
 
       it "returns 1" do
-        (subject <=> other).should == 1
+        expect(subject <=> other).to eq 1
       end
     end
 
@@ -42,28 +42,28 @@ describe ExcelAbstraction::CellReference do
       let(:other){ described_class.new(row: 2, col: 0) }
 
       it "returns -1" do
-        (subject <=> other).should == -1
+        expect(subject <=> other).to eq -1
       end
     end
   end
 
   describe "#succ" do
-    its(:succ){ should == described_class.new(row: 1, col: 2) }
+    its(:succ){ is_expected.to eq described_class.new(row: 1, col: 2) }
   end
 
   describe "#to_s" do
-    its(:to_s){ should == "B2"}
+    its(:to_s){ is_expected.to eq "B2"}
   end
 
   describe "#to_cell_reference" do
-    its(:to_cell_reference){ should == subject }
+    its(:to_cell_reference){ is_expected.to eq subject }
   end
 
   describe "#to_ary" do
-    its(:to_ary){ should == [1, 1] }
+    its(:to_ary){ is_expected.to eq [1, 1] }
   end
 
   describe "#to_a" do
-    its(:to_a){ should == [1, 1] }
+    its(:to_a){ is_expected.to eq [1, 1] }
   end
 end

--- a/spec/excel_abstraction/cell_spec.rb
+++ b/spec/excel_abstraction/cell_spec.rb
@@ -8,7 +8,7 @@ describe ExcelAbstraction::Cell do
       let(:other){ described_class.new(position: 0, val: nil) }
 
       it "return 1" do
-        (subject <=> other).should == 1
+        expect(subject <=> other).to eq 1
       end
     end
 
@@ -16,7 +16,7 @@ describe ExcelAbstraction::Cell do
       let(:other){ described_class.new(position: 1, val: nil) }
 
       it "return 0" do
-        (subject <=> other).should == 0
+        expect(subject <=> other).to eq 0
       end
     end
 
@@ -24,7 +24,7 @@ describe ExcelAbstraction::Cell do
       let(:other){ described_class.new(position: 2, val: nil) }
 
       it "return -1" do
-        (subject <=> other).should == -1
+        expect(subject <=> other).to eq -1
       end
     end
   end
@@ -34,7 +34,7 @@ describe ExcelAbstraction::Cell do
       let(:other){ described_class.new(position: 1, val: "CellValue", style: {bold: true}) }
 
       it "returns true" do
-        (subject == other).should be true
+        expect(subject == other).to be_truthy
       end
     end
 
@@ -42,13 +42,13 @@ describe ExcelAbstraction::Cell do
       let(:other){ described_class.new(position: 1, val: "OtherCellValue", style: {bold: true}) }
 
       it "returns false" do
-        (subject == other).should be false
+        expect(subject == other).to be_falsey
       end
     end
   end
 
   describe "#to_cell" do
-    its(:to_cell){ should == subject }
+    its(:to_cell){ is_expected.to eq subject }
   end
 
 end

--- a/spec/excel_abstraction/date_spec.rb
+++ b/spec/excel_abstraction/date_spec.rb
@@ -5,7 +5,7 @@ describe ExcelAbstraction::Date do
     subject { described_class.new(Date.parse("1900-01-01")) }
 
     it "returns 1.0" do
-      subject.should == 1.0
+      expect(subject).to eq 1.0
     end
   end
 
@@ -13,7 +13,7 @@ describe ExcelAbstraction::Date do
     subject { described_class.new(Date.parse("2000-01-19")) }
 
     it "should return 36544.50 for Jan 19, 2000 12:00" do
-      subject.should == 36544.0
+      expect(subject).to eq 36544.0
     end
   end
 
@@ -21,7 +21,7 @@ describe ExcelAbstraction::Date do
     subject { described_class.new(Date.parse("2012-01-23")) }
 
     it "returns the same object" do
-      subject.to_excel_date.should eq(subject)
+      expect(subject.to_excel_date).to eq(subject)
     end
   end
 end

--- a/spec/excel_abstraction/row_spec.rb
+++ b/spec/excel_abstraction/row_spec.rb
@@ -11,7 +11,7 @@ describe ExcelAbstraction::Row do
     end
 
     it "enumerates over the cell references in the range" do
-      subject.reduce(""){ |str, cell| str += cell.val }.should == "foobarbaz"
+      expect(subject.reduce(""){ |str, cell| str += cell.val }).to eq "foobarbaz"
     end
   end
 
@@ -23,7 +23,7 @@ describe ExcelAbstraction::Row do
     end
 
     it "returns the cell with the given position" do
-      subject[1].val.should eq("bar")
+      expect(subject[1].val).to eq("bar")
     end
   end
 
@@ -35,7 +35,7 @@ describe ExcelAbstraction::Row do
     context "when the cell to be inserted is in the same row" do
       it "inserts the cell" do
         subject << {position: 1, val: "bar"}
-        subject.count.should == 2
+        expect(subject.count).to eq 2
       end
     end
   end

--- a/spec/excel_abstraction/sheet_spec.rb
+++ b/spec/excel_abstraction/sheet_spec.rb
@@ -12,8 +12,8 @@ describe ExcelAbstraction::Sheet do
           subject.header("Foo")
         end
 
-        excel.cell("A", 1).should == "Foo"
-        excel.font("A", 1).should be_bold
+        expect(excel.cell("A", 1)).to eq "Foo"
+        expect(excel.font("A", 1)).to be_bold
       end
     end
   end
@@ -25,10 +25,10 @@ describe ExcelAbstraction::Sheet do
           subject.header(["Foo", "Bar"])
         end
 
-        excel.cell("A", 1).should == "Foo"
-        excel.font("A", 1).should be_bold
-        excel.cell("B", 1).should == "Bar"
-        excel.font("B", 1).should be_bold
+        expect(excel.cell("A", 1)).to eq "Foo"
+        expect(excel.font("A", 1)).to be_bold
+        expect(excel.cell("B", 1)).to eq "Bar"
+        expect(excel.font("B", 1)).to be_bold
       end
     end
   end
@@ -40,7 +40,7 @@ describe ExcelAbstraction::Sheet do
           subject.cell("Foo")
         end
 
-        excel.cell("A", 1).should == "Foo"
+        expect(excel.cell("A", 1)).to eq "Foo"
       end
     end
   end
@@ -52,8 +52,8 @@ describe ExcelAbstraction::Sheet do
           subject.cells(["Foo", "Bar"])
         end
 
-        excel.cell("A", 1).should == "Foo"
-        excel.cell("B", 1).should == "Bar"
+        expect(excel.cell("A", 1)).to eq "Foo"
+        expect(excel.cell("B", 1)).to eq "Bar"
       end
     end
   end
@@ -66,9 +66,9 @@ describe ExcelAbstraction::Sheet do
           subject.cell("Bar")
         end
 
-        excel.cell("A", 1).should == "Foo"
-        excel.cell("B", 1).should be_nil
-        excel.cell("C", 1).should == "Bar"
+        expect(excel.cell("A", 1)).to eq "Foo"
+        expect(excel.cell("B", 1)).to be_nil
+        expect(excel.cell("C", 1)).to eq "Bar"
       end
     end
   end

--- a/spec/excel_abstraction/spread_sheet_spec.rb
+++ b/spec/excel_abstraction/spread_sheet_spec.rb
@@ -5,15 +5,15 @@ describe ExcelAbstraction::SpreadSheet do
   describe "#close" do
     it "closes the excel file" do
       subject.close
-      subject.should be_closed
+      expect(subject).to be_closed
     end
 
     context "when a block is passed" do
       it "executes the block before closing the excel file" do
         test = 0
         subject.close { test += 1 }
-        test.should eq(1)
-        subject.should be_closed
+        expect(test).to eq(1)
+        expect(subject).to be_closed
       end
     end
   end
@@ -29,7 +29,7 @@ describe ExcelAbstraction::SpreadSheet do
       }.to_not raise_exception
 
       File.unlink(file.path)
-      subject.should be_closed
+      expect(subject).to be_closed
     end
   end
 end

--- a/spec/excel_abstraction/time_spec.rb
+++ b/spec/excel_abstraction/time_spec.rb
@@ -5,7 +5,7 @@ describe ExcelAbstraction::Time do
     subject { described_class.new(Time.parse("1900-01-01 00:00 +00:00")) }
 
     it "returns 1.0" do
-      subject.should == 1.0
+      expect(subject).to eq 1.0
     end
   end
 
@@ -13,7 +13,7 @@ describe ExcelAbstraction::Time do
     subject { described_class.new(Time.parse("2000-01-19 12:00 +00:00")) }
 
     it "should return 36544.50 for Jan 19, 2000 12:00" do
-      subject.should == 36544.5
+      expect(subject).to eq 36544.5
     end
   end
 
@@ -21,7 +21,7 @@ describe ExcelAbstraction::Time do
     subject { described_class.new(Time.parse("2012-01-23 14:00")) }
 
     it "returns the same object" do
-      subject.to_excel_time.should eq(subject)
+      expect(subject.to_excel_time).to eq(subject)
     end
   end
 end

--- a/spec/excel_abstraction/work_book_spec.rb
+++ b/spec/excel_abstraction/work_book_spec.rb
@@ -8,14 +8,14 @@ describe ExcelAbstraction::WorkBook do
 
   describe "#title" do
     it "sets the title property" do
-      subject.should_receive(:set_properties).with(title: 'Foo')
+      expect(subject).to receive(:set_properties).with(title: 'Foo')
       subject.title('Foo')
     end
   end
 
   describe "#organization" do
     it "sets the company property" do
-      subject.should_receive(:set_properties).with(company: 'Foo')
+      expect(subject).to receive(:set_properties).with(company: 'Foo')
       subject.organization('Foo')
     end
   end


### PR DESCRIPTION
**Feature:**
Upgrade rspec version to 3.3. Remove all rspec deprecation warnings.
This change will also remove rspec deprecations for Core.

**Ticket:**
https://app.asana.com/0/38725663424910/39428823658476

**Submitter Checklist:**
- [x] CI Passing
- [x] PR Linked to Asana Ticket
- [x] Hound Appeased Acceptably
- [x] No Code Climate Issues
- [x] Class, Module, and public method comments up to spec

**Reviewer Checklist:**
- [ ] New Code Tested Effectively
- [ ] Code organization meets SOP standards
- [ ] Does this code fulfill the ticket?

**Only Then:**
- [ ] Move ticket in Asana
